### PR TITLE
Enable virtual evidence for posterior tasks

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -1,3 +1,6 @@
+3.0.3:
+* segway: enable virtual evidence for posterior tasks
+
 3.0.2:
 * segway: added readthedocs configuration file
 * segway: added conda environment file

--- a/segway/run.py
+++ b/segway/run.py
@@ -4088,14 +4088,16 @@ Use `segway COMMAND --help` for help specific to command COMMAND.
                        help="virtual evidence with priors for labels at each position in "
                        "FILE (default none)")
 
-    group = identify_init.add_argument_group("Flags (annotate-init)")
+    group = identify_init.add_argument_group("Flags "
+                                             "(annotate-init, posterior-init)")
     group.add_argument("-c", "--clobber", action="store_true",
                        help="delete any preexisting files and assumes any "
                        "model files specified in options as output to be "
                        "overwritten")
 
     # select coords to identify in the init step
-    group = identify_init.add_argument_group("Data selection (annotate-init)")
+    group = identify_init.add_argument_group("Data selection "
+                                             "(annotate-init, posterior-init)")
     group.add_argument("--include-coords", metavar="FILE",
                        help="limit to genomic coordinates in"
                        " FILE (default all) (Note: does not apply to"
@@ -4117,7 +4119,10 @@ Use `segway COMMAND --help` for help specific to command COMMAND.
                        " (default none)")
 
     group = identify_init_run.add_argument_group("Virtual Evidence "
-                                              "(annotate-init, annotate-run)")
+                                                 "(annotate-init, "
+                                                 "posterior-init, "
+                                                 "annotate-run, "
+                                                 "posterior-run)")
     group.add_argument("--virtual-evidence", metavar="FILE",
                        help="virtual evidence with priors for labels at each position in "
                        "FILE (default none)")
@@ -4162,11 +4167,12 @@ Use `segway COMMAND --help` for help specific to command COMMAND.
                      usage = "segway annotate-finish [args] GENOMEDATA TRAINDIR ANNOTATEDIR")
 
     # posterior and identify take the same options
-    tasks.add_parser("posterior-init", parents=[identify_init, args,
+    tasks.add_parser("posterior-init", parents=[identify_init,
+                                                identify_init_run, args,
                                                 identify_args],
                      usage = "segway posterior-init [args] GENOMEDATA TRAINDIR POSTDIR")
-    tasks.add_parser("posterior-run", parents=[identify_run, args,
-                                               identify_args],
+    tasks.add_parser("posterior-run", parents=[identify_run, identify_init_run,
+                                               args, identify_args],
                      usage = "segway posterior-run [args] GENOMEDATA TRAINDIR POSTDIR")
     tasks.add_parser("posterior-finish", parents=[identify_finish, args,
                                                   identify_args],

--- a/segway/run.py
+++ b/segway/run.py
@@ -2160,7 +2160,39 @@ class Runner(object):
 
         self.virtual_evidence_coords = virtual_evidence_coords
         self.virtual_evidence_priors = virtual_evidence_priors
+    
+    def get_virtual_evidence_in_window(self, window):
+        """Returns a tuple of a list of coords and their cooresponding
+        dictionary of priors based on the region described the window"""
 
+        # Return no virtual evidence if it is not enabled
+        virtual_evidence_coords = None
+        virtual_evidence_priors = None
+        # Otherwise
+        if self.virtual_evidence:
+            virtual_evidence_coords = []
+            virtual_evidence_priors = []
+            # Iterate over all VE coordinates and corresponding priors
+            zipper = zip(
+                self.virtual_evidence_coords[(window.world, window.chrom)],
+                self.virtual_evidence_priors[(window.world, window.chrom)]
+            )
+            for ve_coord, ve_prior in zipper:
+                # A VE coord does not overlap with the window if its interval
+                # ends entirely before the start of the window or starts
+                # entirely after the end of the window
+                # e.g. ve_coord[1] < window.start or ve_coord[0] > window.end
+                # Negate that condition (so a VE coord does overlap) for the
+                # following:
+                if ve_coord[1] >= window.start and ve_coord[0] <= window.end:
+                    # On VE coordinate overlap with window
+                    # Append to our resulting list
+                    virtual_evidence_coords.append(ve_coord)
+                    virtual_evidence_priors.append(ve_prior)
+        
+        # Return list of VE coords and corresponding priors
+        return (virtual_evidence_coords, virtual_evidence_priors)
+                
     def set_supervision_label_range_size(self, new_extension):
         """This function takes a new label extension new_extension,
         and add it into the supervision_label_range_size set.
@@ -2540,14 +2572,8 @@ class Runner(object):
                 supervision_coords = None
                 supervision_labels = None
 
-            if self.virtual_evidence:
-                virtual_evidence_coords = \
-                    self.virtual_evidence_coords[(window.world, window.chrom)]
-                virtual_evidence_priors = \
-                    self.virtual_evidence_priors[(window.world, window.chrom)]
-            else:
-                virtual_evidence_coords = None
-                virtual_evidence_priors = None
+            virtual_evidence_coords, virtual_evidence_priors = \
+                self.get_virtual_evidence_in_window(window)
 
             additional_prefix_args = [
                genomedata_names_text,
@@ -3634,14 +3660,8 @@ to find the winning instance anyway.""" % thread.instance_index)
         track_indexes_text = ",".join(map(str, track_indexes))
         genomedata_names_text = ",".join(genomedata_names)
 
-        if self.virtual_evidence:
-            virtual_evidence_coords = \
-                self.virtual_evidence_coords[(window.world, window.chrom)]
-            virtual_evidence_priors = \
-                self.virtual_evidence_priors[(window.world, window.chrom)]
-        else:
-            virtual_evidence_coords = None
-            virtual_evidence_priors = None
+        virtual_evidence_coords, virtual_evidence_priors = \
+            self.get_virtual_evidence_in_window(window)
 
         # Prefix args all get mapped with "str" function!
         prefix_args = [find_executable("segway-task"), "run", kind,


### PR DESCRIPTION
It seems that virtual evidence was accidentally not put as an option since the parser was missing for posterior. It's been re-enabled but has been proven difficult to test. Any feedback would be appreciated.