### PR TITLE
Posterior and resolution fix

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -1,3 +1,6 @@
+3.0.3:
+* segway: fixed posterior label output not working with resolutions greater than 1bp
+
 3.0.2:
 * segway: added readthedocs configuration file
 * segway: added conda environment file

--- a/doc/segway.rst
+++ b/doc/segway.rst
@@ -256,11 +256,6 @@ across all instances.
 Resolution
 ----------
 
-.. important::
-
-  The resolution feature is not implemented for posterior use in the Segway
-  |version| release.
-
 In order to speed up the inference process, you may downsample the
 data to a different resolution using the :option:`--resolution`\=\
 *res* option. This means that Segway will partition the input
@@ -778,20 +773,22 @@ A simple mnemonic file appears below::
 
 Posterior task
 ==============
-The **posterior** inference task of Segway estimates for each position
-of interest the probability that the model has a particular segment
-label given the data. This information is delivered in a series of
-numbered wiggle files, one for each segment label. In hierarchical 
-segmentation mode, setting the `--output-label` option to *full* or
-*subseg* will cause segway to produce a wiggle file for each sublabel
-instead, identified using the label and the sublabel in the file name 
-before the file extension. For example, the bedGraph file for label 0, 
-and sublabel 1 would be called ``posterior0.1.bedGraph``. The individual 
-values will vary from 0 to 100, showing the percentage probability at 
-each position for the label in that file. In most positions, the value 
-will be 0 or 100, and substantially reproduce the Viterbi path 
-determined from the **annotate** task. The **posterior** task uses the 
-same options for specifying a model and parameters as **annotate**.
+The **posterior** inference task of Segway estimates for each position of
+interest the probability that the model has a particular resolution-sized
+section given the data. The posterior output does not fall on segment
+boundaries since segment duration is itself probabilistically modeled.
+This information is delivered in a series of numbered BED files, one for each
+segment label. In hierarchical segmentation mode, setting the
+`--output-label` option to *full* or *subseg* will cause segway to produce a
+wiggle file for each sublabel instead, identified using the label and the
+sublabel in the file name before the file extension. For example, the
+bedGraph file for label 0, and sublabel 1 would be called
+``posterior0.1.bedGraph``. The individual values will vary from 0 to 100,
+showing the percentage probability at each position for the label in that
+file. In most positions, the value will be 0 or 100, and substantially
+reproduce the Viterbi path determined from the **annotate** task. The
+**posterior** task uses the same options for specifying a model and
+parameters as **annotate**.
 
 Posterior results can be useful in determining regions of ambiguous
 labeling or in diagnosing new models. The mostly binary nature of the


### PR DESCRIPTION
This PR should fix the `--resolution` option to work with posterior output. Notably, the `posterior.code` output did work before since it relied on the `bed_write` function.

To establish a test and ground truth for this change, the `data` testcase had to be changed to a resolution >1bp, and it was changed to 10 in my particular case. Other testcases didn't have sufficiently different data to detect this problem otherwise. The posterior output probability list (in `probs`) was written out to file for every GMTK frame (which was 10bp long sections) as a BED file at 10 bp intervals for every datapoint. To preserve the previous run length encoding, this established reference was merged with bedTools with the command `groupBy -i new_baseline.0.bed -g 1,4 -c 2,3 -o min,max | awk -v OFS="\t" '{print $1,$3,$4,$2}' > posterior0.0.merged.bed`.

The code changes were then compared against this established baseline and the start and end coordinates were verified with the viterbi output and also ensured no probabilities/datapoints were missing.

There is a consideration to change the data testcase to 10bp resolution since it also runs posterior already.