### PR TITLE
Add CITATION.cff

### DIFF
--- a/CITATION.cff
+++ b/CITATION.cff
@@ -3,11 +3,11 @@ title: Segway
 version: 3.0.3
 date-released: "2020-01-22"
 message: If you use this software, please cite both the article from preferred-citation and the software itself.
-abstract: This software implements a method of semi-automated genome annotation
+abstract: This software implements a method of segmentation and genome annotation
 authors:
   - family-names: Hoffman
     given-names: Michael M.
-    affiliation: "Princess Margaret Cancer Centre"
+    affiliation: "University Health Network"
     orcid: "https://orcid.org/0000-0002-4517-1562"
 license: GPL-2.0-only
 repository-code: "https://github.com/hoffmangroup/segway"
@@ -19,16 +19,18 @@ preferred-citation:
   authors:
     - family-names: Hoffman
       given-names: Michael M.
-      affiliation: "Princess Margaret Cancer Centre"
+      affiliation: "University of Washington"
       orcid: "https://orcid.org/0000-0002-4517-1562"
     - family-names: Buske
       given-names: Orion J.
-      affiliation: "The Hospital for Sick Children"
+      affiliation: "University of Washington"
       orcid: "https://orcid.org/0000-0002-9064-092X"
     - family-names: Wang
       given-names: Jie
+      affiliation: "University of Massachusetts Medical School"
     - family-names: Weng
       given-names: Zhiping
+      affiliation: "University of Massachusetts Medical School"
     - family-names: Bilmes
       given-names: Jeff A.
       affiliation: "University of Washington"

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -1,0 +1,43 @@
+cff-version: 1.2.0
+title: Segway
+version: 3.0.3
+date-released: "2020-01-22"
+message: If you use this software, please cite both the article from preferred-citation and the software itself.
+abstract: This software implements a method of semi-automated genome annotation
+authors:
+  - family-names: Hoffman
+    given-names: Michael M.
+    affiliation: "Princess Margaret Cancer Centre"
+    orcid: "https://orcid.org/0000-0002-4517-1562"
+license: GPL-2.0-only
+repository-code: "https://github.com/hoffmangroup/segway"
+url: "https://segway.hoffmanlab.org"
+preferred-citation:
+  type: edited-work
+  title: Unsupervised pattern discovery in human chromatin structure through genomic segmentation
+  year: 2012
+  authors:
+    - family-names: Hoffman
+      given-names: Michael M.
+      affiliation: "Princess Margaret Cancer Centre"
+      orcid: "https://orcid.org/0000-0002-4517-1562"
+    - family-names: Buske
+      given-names: Orion J.
+      affiliation: "The Hospital for Sick Children"
+      orcid: "https://orcid.org/0000-0002-9064-092X"
+    - family-names: Wang
+      given-names: Jie
+    - family-names: Weng
+      given-names: Zhiping
+    - family-names: Bilmes
+      given-names: Jeff A.
+      affiliation: "University of Washington"
+      orcid: "https://orcid.org/0000-0002-7372-8778"
+    - family-names: Noble
+      affiliation: "University of Washington"
+      orcid: "https://orcid.org/0000-0001-7283-4715"
+      given-names: William Stafford
+  doi: 10.1038/nmeth.1937
+  journal: "Nature Methods"
+  publisher:
+    name: "Nature Portfolio"


### PR DESCRIPTION
Schema version 1.2.0

There's some metadata that may be added in a automated fashion with some additional consideration. Notably there is a [Zenodo integration with Github](https://guides.github.com/activities/citable-code/) that would provide a `doi` field. The commit hash is missing but could be included on possibly on push/tags, e.g.:
```
on:  
  push:
    tags:
      - '*'
```
But then the commit ID would refer to the change made to the CITATION.cff itself (which would always technically be true).