### PR TITLE
Fix wrong thickStart values in segway.bed

### DIFF
--- a/segway/output.py
+++ b/segway/output.py
@@ -54,7 +54,10 @@ def concatenate_window_segmentations(window_filenames, header, outfilename):
                 # write the last line and the first line, after
                 # potentially merging
                 if last_vals == (chrom, start, seg):
+                    # update start position
                     first_row[INDEX_BED_START] = last_start
+                    # update thickStart position
+                    first_row[INDEX_BED_START + 5] = last_start
 
                     # add back trailing newline eliminated by line.split()
                     merged_line = "\t".join(first_row) + "\n"

--- a/segway/output.py
+++ b/segway/output.py
@@ -15,6 +15,7 @@ from .layer import layer, make_layer_filename
 from ._util import Copier, maybe_gzip_open
 
 INDEX_BED_START = 1
+INDEX_BED_THICKSTART = INDEX_BED_START + 5
 
 def make_bed_attr(key, value):
     if " " in value:
@@ -57,7 +58,7 @@ def concatenate_window_segmentations(window_filenames, header, outfilename):
                     # update start position
                     first_row[INDEX_BED_START] = last_start
                     # update thickStart position
-                    first_row[INDEX_BED_START + 5] = last_start
+                    first_row[INDEX_BED_THICKSTART] = last_start
 
                     # add back trailing newline eliminated by line.split()
                     merged_line = "\t".join(first_row) + "\n"


### PR DESCRIPTION
This PR addresses an issue caught while running CNVway where the segway.bed file on observation under the UCSC Genome Browser showed segments with varying thickness. Segway is supposed to have the entire segment displayed as thick.