### PR TITLE
Colorbrewer replacement with palettable

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -1,4 +1,5 @@
 3.0.6:
+* replace colorbrewer dependency with palettable
 * fix pathlib and pkg_resources deprecations
 
 3.0.5:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -15,12 +15,12 @@ classifiers = [
 ]
 dependencies = [
   "autolog>=0.2.0",
-  "colorbrewer>=0.2.0",
   "drmaa>=0.4a3",
   "genomedata>=1.7",
   "numpy",
   "optbuild>=0.2.0",
   "optplus>=0.2.0",
+  "palettable>=3.3.3",
   "path.py>=11",
   "six",
   "tables>2.0.4",

--- a/segway/_util.py
+++ b/segway/_util.py
@@ -18,7 +18,7 @@ import re
 from string import Template
 import sys
 
-import colorbrewer
+from palettable import colorbrewer
 from numpy import (append, array, empty, insert, intc, maximum, str_, zeros)
 from optbuild import Mixin_UseFullProgPath, OptionBuilder_ShortOptWithSpace_TF
 from path import Path
@@ -96,7 +96,7 @@ OFFSET_END = 1
 OFFSET_STEP = 2
 
 NUM_COLORS = 8
-SCHEME = colorbrewer.Dark2[NUM_COLORS]
+SCHEME = colorbrewer.qualitative.Dark2_8.colors
 
 KB = 2 ** 10
 MB = 2 ** 20

--- a/segway/_util.py
+++ b/segway/_util.py
@@ -13,14 +13,14 @@ from importlib import resources
 from itertools import repeat
 from math import floor, log10
 from os import extsep
-from packaging.version import parse as parse_version
 import re
 from string import Template
 import sys
 
-from palettable import colorbrewer
 from numpy import (append, array, empty, insert, intc, maximum, str_, zeros)
 from optbuild import Mixin_UseFullProgPath, OptionBuilder_ShortOptWithSpace_TF
+from packaging.version import parse as parse_version
+from palettable import colorbrewer
 from path import Path
 from six import viewitems
 from six.moves import map, zip


### PR DESCRIPTION
Notably there is some duplication on the new lines

```python
NUM_COLORS = 8
SCHEME = colorbrewer.qualitative.Dark2_8.colors
```

However there seems to be some automagic on import making using `importlib.import_module` not work when trying to import directly.
For example the following does not work:
```python
import_module("palettable.colorbrewer.qualitative.Dark2_8")
```

The following does work:
```python
import_module("palettable.colorbrewer.qualitative")
```

Trying to format an import string to match the `NUM_COLORS` constant seems tricky to work around and might add even more fragility than a duplicated number.